### PR TITLE
script to download mks assets and create the assets folder

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -2142,8 +2142,10 @@
 //
 // TFT LVGL UI
 //
-// Default MKS icons and fonts: https://git.io/JJvzK
-// Copy mks_pic and mks_font folders to the root of your SD
+// Just copy the `assets` folder from the build directory to the root
+// of your SD, together with the compiled firmware.
+//
+// Default MKS icons and fonts used: https://git.io/JJvzK
 //
 //#define TFT_LVGL_UI
 

--- a/buildroot/share/PlatformIO/scripts/dowload_mks_assets.py
+++ b/buildroot/share/PlatformIO/scripts/dowload_mks_assets.py
@@ -1,0 +1,42 @@
+Import("env")
+import os
+import requests
+import zipfile
+import tempfile
+import shutil
+
+url = "https://github.com/makerbase-mks/Mks-Robin-Nano-Marlin2.0-Firmware/archive/master.zip"
+zip_path = os.path.join(env.Dictionary("PROJECT_LIBDEPS_DIR"), "mks-assets.zip")
+assets_path = os.path.join(env.Dictionary("PROJECT_BUILD_DIR"), env.Dictionary("PIOENV"), "assets")
+
+def download_mks_assets():
+	print("Downloading MKS Assets")
+	r = requests.get(url, stream=True)
+	with open(zip_path, 'wb') as fd:
+		for chunk in r.iter_content(chunk_size=128):
+			fd.write(chunk)
+
+def copy_mks_assets():
+	print("Copying MKS Assets")
+	output_path = tempfile.TemporaryDirectory()
+	zip_obj = zipfile.ZipFile(zip_path, 'r')
+	zip_obj.extractall(output_path.name)
+	zip_obj.close()
+	if os.path.exists(assets_path) == True and os.path.isdir(assets_path) == False:
+		os.unlink(assets_path)
+	if os.path.exists(assets_path) == False:
+		os.mkdir(assets_path)
+	base_path = ''
+	for filename in os.listdir(output_path.name):
+		base_path = filename
+	for filename in os.listdir(os.path.join(output_path.name, base_path, 'Firmware', 'mks_font')):
+		shutil.copy(os.path.join(output_path.name, base_path, 'Firmware', 'mks_font', filename), assets_path)
+	for filename in os.listdir(os.path.join(output_path.name, base_path, 'Firmware', 'mks_pic')):
+		shutil.copy(os.path.join(output_path.name, base_path, 'Firmware', 'mks_pic', filename), assets_path)
+	output_path.cleanup()
+
+if os.path.exists(zip_path) == False:
+	download_mks_assets()
+
+if os.path.exists(assets_path) == False:
+	copy_mks_assets()

--- a/platformio.ini
+++ b/platformio.ini
@@ -565,6 +565,8 @@ extends       = env:mks_robin_nano
 extra_scripts = buildroot/share/PlatformIO/scripts/mks_robin_nano35.py
 lib_deps      = ${common_stm32f1.lib_deps}
   MKS-LittlevGL=https://github.com/makerbase-mks/MKS-LittlevGL/archive/master.zip
+extra_scripts = ${env:mks_robin_nano.extra_scripts}
+  buildroot/share/PlatformIO/scripts/dowload_mks_assets.py
 
 #
 # MKS Robin (STM32F103ZET6)
@@ -698,6 +700,8 @@ src_filter    = ${common.default_src_filter} +<src/HAL/STM32F1>
 lib_deps      = ${common.lib_deps}
   SoftwareSerialM
   MKS-LittlevGL=https://github.com/makerbase-mks/MKS-LittlevGL/archive/master.zip
+extra_scripts = ${env:chitu_f103.extra_scripts}
+  buildroot/share/PlatformIO/scripts/dowload_mks_assets.py
 
 #
 # Creality (STM32F103RET6)


### PR DESCRIPTION
I created the build script to download the mks assets and create the new assets folder in the build root.

First I download the master.zip to the lib dirs. This way, it keeps cached until the user delete the file, so there's no need to download in every build.

If the assets folder in the build root don't exists, the script will create and copy the files.

