### PR TITLE
Fix bugs

### DIFF
--- a/Marlin/src/lcd/extui/lib/mks_ui/draw_home.cpp
+++ b/Marlin/src/lcd/extui/lib/mks_ui/draw_home.cpp
@@ -66,8 +66,8 @@ static void event_handler(lv_obj_t *obj, lv_event_t event) {
       queue.inject_P(PSTR("M84 X Y"));
       break;
     case ID_H_RETURN:
-      lv_clear_home();
-      lv_draw_tool();
+      clear_cur_ui();
+      draw_return_ui();
       break;
   }
 }

--- a/Marlin/src/lcd/extui/lib/mks_ui/draw_tool.cpp
+++ b/Marlin/src/lcd/extui/lib/mks_ui/draw_tool.cpp
@@ -50,7 +50,12 @@ enum {
 
 static void event_handler(lv_obj_t *obj, lv_event_t event) {
   if (event != LV_EVENT_RELEASED) return;
-  lv_clear_tool();
+  #if ENABLED(AUTO_BED_LEVELING_BILINEAR)
+    bool clear = (obj->mks_obj_id != ID_T_LEVELING);
+  #else
+    constexpr bool clear = true;
+  #endif
+  if (clear) lv_clear_tool();
   switch (obj->mks_obj_id) {
     case ID_T_PRE_HEAT:
       lv_draw_preHeat();

--- a/Marlin/src/lcd/extui/lib/mks_ui/draw_ui.cpp
+++ b/Marlin/src/lcd/extui/lib/mks_ui/draw_ui.cpp
@@ -585,15 +585,16 @@ char *creat_title_text() {
     index++;
   }
 
-  if (disp_state_stack._disp_state[disp_state_stack._disp_index] == PRINTING_UI
-  ) {
+  if (disp_state_stack._disp_state[disp_state_stack._disp_index] == PRINTING_UI) {
     titleText_cat(public_buf_m, sizeof(public_buf_m), (char *)":");
     titleText_cat(public_buf_m, sizeof(public_buf_m), tmpCurFileStr);
   }
 
   if (strlen(public_buf_m) > MAX_TITLE_LEN) {
     ZERO(public_buf_m);
-    tmpText = getDispText(0);
+    tmpText = 0;
+    for (index = 0; index <= disp_state_stack._disp_index && (!tmpText || *tmpText == 0); index++) 
+      tmpText = getDispText(index);
     if (*tmpText != 0) {
       titleText_cat(public_buf_m, sizeof(public_buf_m), tmpText);
       titleText_cat(public_buf_m, sizeof(public_buf_m), (char *)">...>");


### PR DESCRIPTION
### Requirements

This is a general purpose fixing, no specific printer is required

### Description

These 2 commits fix 2 bugs:

1. When selecting Autoleveling in the menu, the screen is cleared and no other menu appear (only happens with a BLTouch sensor). 
2. The title in the different menu disappears (for example, if you go from Home to Move to Home to Move, the second time, you won't get a title)

This happens because the home menu did not used the display stack correctly **and** because the `create_title_text` function had a bug when the first item in the display stack does not produce a title (and it's always the case since the first item is a "MAIN_MENU")

### Benefits

1. Prevent the printer to appear broken when using Auto leveling
2. Show a meaningful title on each menu in all cases

### Related Issues

Sorry, I haven't created issues, see above for issue description.
