### PR TITLE
Add status in move menu

### DIFF
--- a/Marlin/src/lcd/extui/lib/mks_ui/draw_cloud_bind.cpp
+++ b/Marlin/src/lcd/extui/lib/mks_ui/draw_cloud_bind.cpp
@@ -29,7 +29,7 @@
 #include "../../../../MarlinCore.h"
 #include "../../../../module/temperature.h"
 
-#include "qr_encode.h"
+#include "QR_Encode.h"
 
 extern lv_group_t * g;
 static lv_obj_t * scr;

--- a/Marlin/src/lcd/extui/lib/mks_ui/draw_home.cpp
+++ b/Marlin/src/lcd/extui/lib/mks_ui/draw_home.cpp
@@ -66,8 +66,8 @@ static void event_handler(lv_obj_t *obj, lv_event_t event) {
       queue.inject_P(PSTR("M84 X Y"));
       break;
     case ID_H_RETURN:
-      lv_clear_home();
-      lv_draw_tool();
+      clear_cur_ui();
+      draw_return_ui();
       break;
   }
 }

--- a/Marlin/src/lcd/extui/lib/mks_ui/draw_tool.cpp
+++ b/Marlin/src/lcd/extui/lib/mks_ui/draw_tool.cpp
@@ -50,7 +50,12 @@ enum {
 
 static void event_handler(lv_obj_t *obj, lv_event_t event) {
   if (event != LV_EVENT_RELEASED) return;
-  lv_clear_tool();
+  #if ENABLED(AUTO_BED_LEVELING_BILINEAR)
+    bool clear = (obj->mks_obj_id != ID_T_LEVELING);
+  #else
+    constexpr bool clear = true;
+  #endif
+  if (clear) lv_clear_tool();
   switch (obj->mks_obj_id) {
     case ID_T_PRE_HEAT:
       lv_draw_preHeat();

--- a/Marlin/src/lcd/extui/lib/mks_ui/draw_ui.cpp
+++ b/Marlin/src/lcd/extui/lib/mks_ui/draw_ui.cpp
@@ -585,15 +585,16 @@ char *creat_title_text() {
     index++;
   }
 
-  if (disp_state_stack._disp_state[disp_state_stack._disp_index] == PRINTING_UI
-  ) {
+  if (disp_state_stack._disp_state[disp_state_stack._disp_index] == PRINTING_UI) {
     titleText_cat(public_buf_m, sizeof(public_buf_m), (char *)":");
     titleText_cat(public_buf_m, sizeof(public_buf_m), tmpCurFileStr);
   }
 
   if (strlen(public_buf_m) > MAX_TITLE_LEN) {
     ZERO(public_buf_m);
-    tmpText = getDispText(0);
+    tmpText = 0;
+    for (index = 0; index <= disp_state_stack._disp_index && (!tmpText || *tmpText == 0); index++) 
+      tmpText = getDispText(index);
     if (*tmpText != 0) {
       titleText_cat(public_buf_m, sizeof(public_buf_m), tmpText);
       titleText_cat(public_buf_m, sizeof(public_buf_m), (char *)">...>");


### PR DESCRIPTION
### Requirements

The PR #32 must be merged

### Description

This PR adds a status label on the top right of the move menu that's displaying the last modified axis position so it's possible to know where the printer is (and is very useful to calibrate a BLTouch sensor for example). It used to be in the previous firmware but it's not anymore in MKS, so I'm adding the feature again.

### Benefits

This gives immediate feedback of the printer position when moving it (a feature really missing IMHO)

### Related Issues

Requires the bug listed in #32 to be fixed, so please merge the #32 first and then you can cherry pick the new commit.
