### PR TITLE
[FIX] Case sensitive include on Linux

### DIFF
--- a/Marlin/src/lcd/extui/lib/mks_ui/draw_cloud_bind.cpp
+++ b/Marlin/src/lcd/extui/lib/mks_ui/draw_cloud_bind.cpp
@@ -29,7 +29,7 @@
 #include "../../../../MarlinCore.h"
 #include "../../../../module/temperature.h"
 
-#include "qr_encode.h"
+#include "QR_Encode.h"
 
 extern lv_group_t * g;
 static lv_obj_t * scr;


### PR DESCRIPTION
### Requirements

Visual Studio Code on Ubuntu 20.04

### Description

As the imported QR code library has a file named "QR_Encode.h" instead of the included "qr_encode.h", the compilation fails on Linux

### Benefits

It's possible to compile on Linux

### Related Issues

n/a
